### PR TITLE
Remove the call to `real` when rounding to integer indexes

### DIFF
--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -2,7 +2,7 @@ immutable Constant <: Degree{0} end
 
 function define_indices_d(::Type{BSpline{Constant}}, d, pad)
     symix, symx = symbol("ix_",d), symbol("x_",d)
-    :($symix = clamp(round(Int, real($symx)), 1, size(itp, $d)))
+    :($symix = clamp(round(Int, $symx), 1, size(itp, $d)))
 end
 
 function coefficients(::Type{BSpline{Constant}}, N, d)

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -3,7 +3,7 @@ immutable Linear <: Degree{1} end
 function define_indices_d(::Type{BSpline{Linear}}, d, pad)
     symix, symixp, symfx, symx = symbol("ix_",d), symbol("ixp_",d), symbol("fx_",d), symbol("x_",d)
     quote
-        $symix = clamp(floor(Int, real($symx)), 1, size(itp, $d)-1)
+        $symix = clamp(floor(Int, $symx), 1, size(itp, $d)-1)
         $symixp = $symix + 1
         $symfx = $symx - $symix
     end

--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -7,7 +7,7 @@ function define_indices_d{BC}(::Type{BSpline{Quadratic{BC}}}, d, pad)
     quote
         # ensure that all three ix_d, ixm_d, and ixp_d are in-bounds no matter
         # the value of pad
-        $symix = clamp(round(Int, real($symx)), 2-$pad, size(itp,$d)+$pad-1)
+        $symix = clamp(round(Int, $symx), 2-$pad, size(itp,$d)+$pad-1)
         $symfx = $symx - $symix
         $symix += $pad # padding for oob coefficient
         $symixp = $symix + 1
@@ -18,7 +18,7 @@ function define_indices_d(::Type{BSpline{Quadratic{Periodic}}}, d, pad)
     symix, symixm, symixp = symbol("ix_",d), symbol("ixm_",d), symbol("ixp_",d)
     symx, symfx = symbol("x_",d), symbol("fx_",d)
     quote
-        $symix = clamp(round(Int, real($symx)), 1, size(itp,$d))
+        $symix = clamp(round(Int, $symx), 1, size(itp,$d))
         $symfx = $symx - $symix
         $symixp = mod1($symix + 1, size(itp,$d))
         $symixm = mod1($symix - 1, size(itp,$d))
@@ -31,7 +31,7 @@ function define_indices_d{BC<:Union{InPlace,InPlaceQ}}(::Type{BSpline{Quadratic{
     quote
         # ensure that all three ix_d, ixm_d, and ixp_d are in-bounds no matter
         # the value of pad
-        $symix = clamp(round(Int, real($symx)), 1, size(itp,$d))
+        $symix = clamp(round(Int, $symx), 1, size(itp,$d))
         $symfx = $symx - $symix
         $symix += $pad # padding for oob coefficient
         $symixp = min(size(itp,$d), $symix + 1)


### PR DESCRIPTION
The deprecation of `real` for DualNumbers broke the tests that used `@inferrable`. More long-term, I think it's better to just perform the operation we want without an extra call to `real`. This places the onus on the relevant number types to support `round(Int, x)`, but the two major use-cases for automatic differentiation (ForwardDiff and DualNumbers) now support this.Interpolations.jl